### PR TITLE
Fixed JsExpression() error in 'eventClick'

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Below is an example of a controller action configuring the calendar
             'selectable'  => true,
             'defaultView' => 'agendaWeek',
             // Add the callbacks
-            'eventClick' => \Edofre\Fullcalendar\JsExpression("
+            'eventClick' => new \Edofre\Fullcalendar\JsExpression("
                 function(event, jsEvent, view) {
                     console.log(event);
                 }


### PR DESCRIPTION
Added "new" before "\Edofre\Fullcalendar\JsExpression()" instantiation